### PR TITLE
Fix: docs.microsoft.com to learn.microsoft.com

### DIFF
--- a/developer-notes.md
+++ b/developer-notes.md
@@ -9,7 +9,7 @@
 
 ## Test plan
 
-- Open an [article](https://docs.microsoft.com/azure/azure-functions/functions-create-your-first-function-visual-studio) on _docs.microsoft.com_:
+- Open an [article](https://learn.microsoft.com/azure/azure-functions/functions-create-your-first-function-visual-studio) on _learn.microsoft.com_:
 
-  - Click on the **Edit** button
-  - Click on the **Email Author** button
+  - Select the **Edit** button
+  - Select the **Email Author** button

--- a/src/background/listeners.js
+++ b/src/background/listeners.js
@@ -8,7 +8,7 @@ const actions = {
       message
         - action: Always equals 'log' in this function
         - url:    The public URL of the published article
-        - source: Domain hostname, for example: 'docs.microsoft.com'
+        - source: Domain hostname, for example: 'learn.microsoft.com'
     */
 
     if (IS_PRODUCTION) {
@@ -34,7 +34,7 @@ chrome.runtime.onInstalled.addListener(() => {
   chrome.declarativeContent.onPageChanged.removeRules(undefined, () => {
     chrome.declarativeContent.onPageChanged.addRules([
       {
-        conditions: [createCondition('docs.microsoft.com')],
+        conditions: [createCondition('learn.microsoft.com')],
         actions: [new chrome.declarativeContent.ShowPageAction()],
       },
     ]);

--- a/src/content.js
+++ b/src/content.js
@@ -33,8 +33,8 @@ window.commonRules = {
 const getWebPropertyKey = (url, hostname) => {
   let returnValue = '';
 
-  if (hostname === 'docs.microsoft.com') {
-    returnValue = 'docs';
+  if (hostname === 'learn.microsoft.com') {
+    returnValue = 'learn';
   }
 
   return returnValue;

--- a/src/extension.html
+++ b/src/extension.html
@@ -29,7 +29,7 @@
     <div class="container">
       <div>
         Edit articles on
-        <a href="http://docs.microsoft.com" target="_blank">docs.microsoft.com</a> in the private
+        <a href="http://learn.microsoft.com" target="_blank">learn.microsoft.com</a> in the private
         repo by clicking on either the:
         <ul>
           <li>

--- a/src/github.js
+++ b/src/github.js
@@ -64,7 +64,7 @@ function getAuthor() {
 
 function getPublicUrl() {
   let url = '';
-  const a = document.querySelector('a[href^="https://docs.microsoft.com"]');
+  const a = document.querySelector('a[href^="https://learn.microsoft.com"]');
   if (a) {
     url = a.getAttribute('href');
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,8 +25,8 @@
   "content_scripts": [
     {
       "matches": [
-        "https://docs.microsoft.com/*",
-        "http://docs.microsoft.com/*"
+        "https://learn.microsoft.com/*",
+        "http://learn.microsoft.com/*"
       ],
       "js": ["content.js", "docs.js"],
       "run_at": "document_idle",
@@ -37,8 +37,8 @@
   "permissions": [
     "activeTab",
     "declarativeContent",
-    "https://docs.microsoft.com/*",
-    "http://docs.microsoft.com/*"
+    "https://learn.microsoft.com/*",
+    "http://learn.microsoft.com/*"
   ],
   "content_security_policy": "script-src 'self' https://www.google-analytics.com; object-src 'self'"
 }


### PR DESCRIPTION
SpineEdit has stopped working because of the Learn brand that changed all URLs from `docs.microsoft.com` to `learn.microsoft.com`.