### PR TITLE
Update learn.js to fix new meta name

### DIFF
--- a/src/learn.js
+++ b/src/learn.js
@@ -3,7 +3,7 @@
 webProperties.learn = {
   attribute: 'content',
   rules: getRules(),
-  selector: `meta[name="original_ref_skeleton_git_url"]`,
+  selector: `meta[name="original_content_git_url"]`,
   customize,
   getAlias,
   getAuthor,


### PR DESCRIPTION
@craigshoemaker Heads up, SpineEdit appears to have stopped working. I'm not sure if this is a complete solution, but the meta name appears to have changed. For example: https://learn.microsoft.com/en-us/sql/relational-databases/security/sql-injection?view=sql-server-ver16
![image](https://github.com/user-attachments/assets/2c434c47-1ced-4a69-92c4-44221028d4ac)
